### PR TITLE
minor updates to terraform and docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ services:
   app:
     image: isuru117/cinema-db-backend
     restart: always
-    env_file: .env
+    environment: 
+      - MONGO_DB_URI=${MONGO_DB_URI}
+      - PORT=${MY_APP_PORT}
     ports:
       - '80:3000'
     links:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,13 @@ resource "aws_security_group" "app_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 65535

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,9 +42,3 @@ variable "username" {
     description = "EC2 instance username for SSH"
     default="your user name"
 }
-
-variable "ssh_key" { 
-    description = "Key used to SSH to EC2 instance"
-    default="your_ssh_key"
-}
-


### PR DESCRIPTION
- Adds https port inbound rule for ec2 security group in main.tf
- docker-compose will now use environment variables as args instead of .env 