### PR TITLE
prevent workflow from running both jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,10 @@ jobs:
 workflows:
   build-push-flow:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore: main
       - push:
           filters:
             branches:


### PR DESCRIPTION
- the build and push jobs were running duplicated, which is fixed now 