### PR TITLE
remove old terraform cloud backend file

### DIFF
--- a/terraform/backend.hcl
+++ b/terraform/backend.hcl
@@ -1,3 +1,0 @@
-workspaces { name = "cinemadb-backend" }
-hostname     = "app.terraform.io"
-organization = "isuru117"


### PR DESCRIPTION
- Remove old terraform cloud backend.hcl which is not used anymore